### PR TITLE
fix: import path bug for running error

### DIFF
--- a/app/src/views/FineWeather.vue
+++ b/app/src/views/FineWeather.vue
@@ -120,8 +120,8 @@ import { useDark, useEventListener } from '@vueuse/core'
 import AV from 'leancloud-storage'
 import FingerprintJS from '@fingerprintjs/fingerprintjs'
 import { EmojiReaction } from 'emoji-reaction'
-import ImageCard from './ImageCard.vue'
-import ImageDetail from './ImageDetail.vue'
+import ImageCard from '../components/ImageCard.vue'
+import ImageDetail from '../components/ImageDetail.vue'
 
 const PAGE_SIZE = 20
 const AV_OBJECT_NAME = 'FineWeatherGalleryReaction'


### PR DESCRIPTION
There is a issue with the components path when i first clone the repo and trying to running it locally: 
`yarn && yarn run dev`

it maybe a path typo during refactoring

<img width="1428" alt="image" src="https://github.com/codekitchen-community/fine-weather/assets/81088399/01e2e200-530d-4a06-a18b-74d5fcbb10dd">
